### PR TITLE
Show compressed columns when compressed entries present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 **Changed**
 - Replace `com.jakewharton.diffuse.io.Size` with `me.saket.bytesize.ByteSize` in the APIs.
 - Eliminate `data class` from public APIs.
+- Show compressed columns when compressed entries present.
 
 **Fixed**
 - Significantly improve `.jar` diff performance.

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AabDiff.kt
@@ -6,7 +6,7 @@ import com.jakewharton.diffuse.report.text.AabDiffTextReport
 
 internal class AabDiff(val oldAab: Aab, val newAab: Aab) : BinaryDiff {
   inner class ModuleDiff(val oldModule: Aab.Module, val newModule: Aab.Module) {
-    val archive = ArchiveFilesDiff(oldModule.files, newModule.files, includeCompressed = false)
+    val archive = ArchiveFilesDiff(oldModule.files, newModule.files)
     val dex =
       DexDiff(
         oldModule.dexes.map { it.withMapping(oldAab.apiMapping) },

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/AarDiff.kt
@@ -11,7 +11,7 @@ internal class AarDiff(
   val newAar: Aar,
   val newMapping: ApiMapping,
 ) : BinaryDiff {
-  val archive = ArchiveFilesDiff(oldAar.files, newAar.files, includeCompressed = false)
+  val archive = ArchiveFilesDiff(oldAar.files, newAar.files)
   val jars = JarsDiff(oldAar.jars, oldMapping, newAar.jars, newMapping)
   val manifest = AndroidManifestDiff(oldAar.manifest, newAar.manifest)
 

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ArchiveFilesDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/ArchiveFilesDiff.kt
@@ -18,7 +18,7 @@ import me.saket.bytesize.binaryBytes
 internal class ArchiveFilesDiff(
   val oldFiles: ArchiveFiles,
   val newFiles: ArchiveFiles,
-  val includeCompressed: Boolean = true,
+  val includeCompressed: Boolean = oldFiles.isCompressed || newFiles.isCompressed,
 ) {
   data class Change(
     val path: String,
@@ -235,3 +235,6 @@ internal fun ArchiveFilesDiff.toDetailReport() = buildString {
       .renderText()
   )
 }
+
+private val ArchiveFiles.isCompressed: Boolean
+  get() = values.any { it.isCompressed }

--- a/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
+++ b/reports/src/main/kotlin/com/jakewharton/diffuse/diff/JarDiff.kt
@@ -11,7 +11,7 @@ internal class JarDiff(
   val newJar: Jar,
   val newMapping: ApiMapping,
 ) : BinaryDiff {
-  val archive = ArchiveFilesDiff(oldJar.files, newJar.files, includeCompressed = false)
+  val archive = ArchiveFilesDiff(oldJar.files, newJar.files)
   val jars = JarsDiff(listOf(oldJar), oldMapping, listOf(newJar), newMapping)
 
   val changed = jars.changed || archive.changed


### PR DESCRIPTION
<details><summary>diff:</summary>
<p>

```
OLD: old.jar
NEW: new.jar

       │            compressed            │            uncompressed
       ├────────────┬────────────┬────────┼────────────┬────────────┬───────────
 JAR   │ old        │ new        │ diff   │ old        │ new        │ diff
───────┼────────────┼────────────┼────────┼────────────┼────────────┼───────────
 class │ 139.75 KiB │ 140.23 KiB │ +490 B │ 315.85 KiB │ 316.92 KiB │ +1.06 KiB
 other │   1.67 KiB │   1.67 KiB │    0 B │      465 B │      465 B │       0 B
───────┼────────────┼────────────┼────────┼────────────┼────────────┼───────────
 total │ 141.42 KiB │  141.9 KiB │ +490 B │ 316.31 KiB │ 317.37 KiB │ +1.06 KiB

 CLASSES │ old │ new │ diff
─────────┼─────┼─────┼────────────
 classes │  73 │  73 │  0 (+0 -0)
 methods │ 691 │ 694 │ +3 (+3 -0)
  fields │ 170 │ 170 │  0 (+0 -0)

=================
====   JAR   ====
=================

     compressed     │     uncompressed      │
───────────┬────────┼───────────┬───────────┤
 size      │ diff   │ size      │ diff      │ path
───────────┼────────┼───────────┼───────────┼─────────────────────────────────────────────────────────
  9.45 KiB │ +361 B │  26.2 KiB │    +782 B │ ∆ com/jakewharton/diffuse/diff/ArchiveFilesDiffKt.class
  4.05 KiB │  +50 B │ 10.04 KiB │    +158 B │ ∆ com/jakewharton/diffuse/diff/ArchiveFilesDiff.class
  1.66 KiB │  +28 B │  4.08 KiB │     +49 B │ ∆ com/jakewharton/diffuse/diff/AarDiff.class
   1.7 KiB │  +28 B │  3.93 KiB │     +49 B │ ∆ com/jakewharton/diffuse/diff/JarDiff.class
  2.42 KiB │  +23 B │  5.73 KiB │     +49 B │ ∆ com/jakewharton/diffuse/diff/AabDiff$ModuleDiff.class
───────────┼────────┼───────────┼───────────┼─────────────────────────────────────────────────────────
 19.28 KiB │ +490 B │ 49.99 KiB │ +1.06 KiB │ (total)

=====================
====   CLASSES   ====
=====================

METHODS:

   old │ new │ diff
  ─────┼─────┼────────────
   691 │ 694 │ +3 (+3 -0)

  + com.jakewharton.diffuse.diff.ArchiveFilesDiffKt access$isCompressed(ArchiveFiles) → boolean
  + com.jakewharton.diffuse.diff.ArchiveFilesDiffKt isCompressed(ArchiveFiles) → boolean
  + com.jakewharton.diffuse.format.ArchiveFiles values() → Collection
```

</p>
</details> 


<details><summary>zipinfo:</summary>
<p>

```sh
Archive:  new.jar
Zip file size: 145304 bytes, number of entries: 84
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 META-INF/
-rw-r--r--  2.0 unx       25 b- defN 80-Feb-01 00:00 META-INF/MANIFEST.MF
-rw-r--r--  2.0 unx      440 b- defN 80-Feb-01 00:00 META-INF/com.jakewharton.diffuse_reports.kotlin_module
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/
-rw-r--r--  2.0 unx     4533 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/DiffuseTableDsl.class
-rw-r--r--  2.0 unx     3425 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/PicnicTablesKt.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/
-rw-r--r--  2.0 unx     5872 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/AabDiff$ModuleDiff.class
-rw-r--r--  2.0 unx     8036 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/AabDiff.class
-rw-r--r--  2.0 unx     4182 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/AarDiff.class
-rw-r--r--  2.0 unx     3576 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/AndroidManifestDiff.class
-rw-r--r--  2.0 unx     5076 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/AndroidManifestDiffKt.class
-rw-r--r--  2.0 unx     7886 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ApkDiff.class
-rw-r--r--  2.0 unx     2205 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiff$Change$Type.class
-rw-r--r--  2.0 unx     5583 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiff$Change.class
-rw-r--r--  2.0 unx     5153 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiff$changes$lambda$0$$inlined$sortedByDescending$1.class
-rw-r--r--  2.0 unx    10284 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiff.class
-rw-r--r--  2.0 unx     1068 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiffKt$WhenMappings.class
-rw-r--r--  2.0 unx    26829 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArchiveFilesDiffKt.class
-rw-r--r--  2.0 unx     3547 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArscDiff.class
-rw-r--r--  2.0 unx     1112 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArscDiffKt$toDetailReport$1$1.class
-rw-r--r--  2.0 unx    12655 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ArscDiffKt.class
-rw-r--r--  2.0 unx     6478 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/BinaryDiff$Companion.class
-rw-r--r--  2.0 unx      873 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/BinaryDiff$DefaultImpls.class
-rw-r--r--  2.0 unx     3468 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/BinaryDiff.class
-rw-r--r--  2.0 unx     2462 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ComponentDiff.class
-rw-r--r--  2.0 unx     9725 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/ComponentDiffKt.class
-rw-r--r--  2.0 unx    10081 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/DexDiff.class
-rw-r--r--  2.0 unx     9803 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/DexDiffKt.class
-rw-r--r--  2.0 unx     4026 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/JarDiff.class
-rw-r--r--  2.0 unx    11336 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/JarsDiff.class
-rw-r--r--  2.0 unx     8089 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/JarsDiffKt.class
-rw-r--r--  2.0 unx     1752 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiff.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$2$2.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$2$3.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$3$2.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$3$3.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$4$2.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$4$3.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$5$2.class
-rw-r--r--  2.0 unx     1548 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt$toDetailReport$1$1$5$3.class
-rw-r--r--  2.0 unx     7553 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/SignaturesDiffKt.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/
-rw-r--r--  2.0 unx     1115 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/Notice$Companion$comparator$1.class
-rw-r--r--  2.0 unx     1000 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/Notice$Companion$comparator$2.class
-rw-r--r--  2.0 unx     1335 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/Notice$Companion.class
-rw-r--r--  2.0 unx     2042 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/Notice$Type.class
-rw-r--r--  2.0 unx     4802 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/Notice.class
-rw-r--r--  2.0 unx     2279 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/diff/lint/ResourceArscCompressionKt.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/
-rw-r--r--  2.0 unx     1521 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/AabInfo.class
-rw-r--r--  2.0 unx     1521 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/AarInfo.class
-rw-r--r--  2.0 unx     1521 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/ApkInfo.class
-rw-r--r--  2.0 unx    13540 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/ArchiveFilesInfoKt.class
-rw-r--r--  2.0 unx     3738 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/ArscInfoKt.class
-rw-r--r--  2.0 unx     1443 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/BinaryInfo$Companion.class
-rw-r--r--  2.0 unx      873 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/BinaryInfo$DefaultImpls.class
-rw-r--r--  2.0 unx     1607 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/BinaryInfo.class
-rw-r--r--  2.0 unx     1521 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/DexInfo.class
-rw-r--r--  2.0 unx     9624 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/DexesInfoKt.class
-rw-r--r--  2.0 unx     1521 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/JarInfo.class
-rw-r--r--  2.0 unx     1110 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/JarsInfoKt$toSummaryTable$1$2$2.class
-rw-r--r--  2.0 unx     7420 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/info/JarsInfoKt.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/
-rw-r--r--  2.0 unx     1987 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/ApiMappingsKt.class
-rw-r--r--  2.0 unx      954 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/Report$Factory$DefaultImpls.class
-rw-r--r--  2.0 unx     1535 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/Report$Factory.class
-rw-r--r--  2.0 unx      744 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/Report.class
-rw-r--r--  2.0 unx     2279 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/SignaturesKt.class
-rw-r--r--  2.0 unx     3121 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/StringsKt.class
drwxr-xr-x  2.0 unx        0 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/
-rw-r--r--  2.0 unx    10235 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/AabDiffTextReport.class
-rw-r--r--  2.0 unx     6830 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/AabInfoTextReport.class
-rw-r--r--  2.0 unx     5081 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/AarDiffTextReport.class
-rw-r--r--  2.0 unx     3604 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/AarInfoTextReport.class
-rw-r--r--  2.0 unx      976 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/ApkDiffTextReport$WhenMappings.class
-rw-r--r--  2.0 unx     9967 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/ApkDiffTextReport.class
-rw-r--r--  2.0 unx     3961 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/ApkInfoTextReport.class
-rw-r--r--  2.0 unx     4161 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/DexDiffTextReport.class
-rw-r--r--  2.0 unx     2781 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/DexInfoTextReport.class
-rw-r--r--  2.0 unx     4369 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/JarDiffTextReport.class
-rw-r--r--  2.0 unx     3352 b- defN 80-Feb-01 00:00 com/jakewharton/diffuse/report/text/JarInfoTextReport.class
84 files, 324987 bytes uncompressed, 130272 bytes compressed:  59.9%
```

</p>
</details> 

Closes #538.